### PR TITLE
fix: remove unused files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.2",
   "description": "Like the `Did you mean?` in git for npm",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "devDependencies": {
     "standard": "^11.0.1",
     "standard-version": "^8.0.1",


### PR DESCRIPTION
Removes unused files from the NPM package. Currently it contains not only the test-cases but also github actions:

> npm notice === Tarball Contents === 
> npm notice 1.1kB LICENSE                 
> npm notice 986B  index.js                
> npm notice 431B  test.js                 
> npm notice 634B  package.json            
> npm notice 1.3kB CHANGELOG.md            
> npm notice 1.5kB README.md               
> npm notice 453B  .github/workflows/ci.yml

After the change `test.js` and `.github/workflows/ci.yml` is ignored:

> npm notice === Tarball Contents === 
> npm notice 1.1kB LICENSE     
> npm notice 986B  index.js    
> npm notice 659B  package.json
> npm notice 1.3kB CHANGELOG.md
> npm notice 1.5kB README.md   

File count is dropped to 5 and package size goes from 3.1 kB to 2.7 kB. It might seem like a minor optimization but if we try to keep all the packages in the NPM ecosystem down it helps a lot globally.